### PR TITLE
Support brackets

### DIFF
--- a/spec/autolink_spec.cr
+++ b/spec/autolink_spec.cr
@@ -17,7 +17,7 @@ describe Autolink do
       http://en.wikipedia.org/wiki/Wikipedia:Today%27s_featured_picture_%28animation%29/January_20%2C_2007
       http://www.mail-archive.com/rails@lists.rubyonrails.org/
       http://www.amazon.com/Testing-Equal-Sign-In-Path/ref=pd_bbs_sr_1?ie=UTF8&s=books&qid=1198861734&sr=8-1
-      http://en.wikipedia.org/wiki/Texas_hold'em
+      http://en.wikipedia.org/wiki/Texas_hold\'em
       https://www.google.com/doku.php?id=gps:resource:scs:start
       http://connect.oraclecorp.com/search?search[q]=green+france&search[type]=Group
       http://of.openfoundry.org/projects/492/download#4th.Release.3
@@ -36,7 +36,7 @@ describe Autolink do
     link_result.should eq auto_link(link_result)
   end
 
-  pending "works with brackets" do
+  it "works with brackets" do
     link1_raw = "http://en.wikipedia.org/wiki/Sprite_(computer_graphics)"
     link1_result = generate_result(link1_raw)
     link1_result.should eq auto_link(link1_raw)
@@ -51,6 +51,11 @@ describe Autolink do
     link3_result = generate_result(link3_raw)
     link3_result.should eq auto_link(link3_raw)
     "{link: #{link3_result}}".should eq auto_link("{link: #{link3_raw}}")
+  end
+
+  it "works with multiple brackets" do
+    link_raw = "http://en.wikipedia.org/(wiki)/Sprite_(computer_graphics)"
+    auto_link("[{((#{link_raw}))}]").should eq "[{((#{generate_result(link_raw)}))}]"
   end
 
   it "accepts HTML options" do

--- a/src/autolink.cr
+++ b/src/autolink.cr
@@ -3,17 +3,32 @@ require "./autolink/*"
 module Autolink
   AUTO_LINK_RE = %r{
               (?: ((?:ed2k|ftp|http|https|irc|mailto|news|gopher|nntp|telnet|webcal|xmpp|callto|feed|svn|urn|aim|rsync|tag|ssh|sftp|rtsp|afs|file):)// | www\. )
-              [^\s<"]+[^.$]
+              [^\s<\"]+[^.$]
             }ix
 
   AUTO_LINK_CRE = [/<[^>]+$/, /^[^>]*>/, /<a\b.*?>/i, /<\/a>/i]
 
+  BRACKETS = {"]" => "[", ")" => "(", "}" => "{"}
+
   def auto_link(text, html = {} of String => String)
     text.gsub(AUTO_LINK_RE) do |url|
       next url if auto_linked?($~.pre_match, $~.post_match)
+
+      punctuation = [] of String
+      while (url =~ /[^\p{L}\/-=&]$/)
+        punctuation << $~[0]
+        opening = BRACKETS[punctuation.last]?
+        if opening && url.scan(opening).size >= url.scan(punctuation.last).size
+          punctuation.pop
+          break
+        else
+          url = $~.pre_match
+        end
+      end
+
       attrs = {"href" => url}
       attrs.merge!(html) unless html.empty?
-      content_tag(:a, url, attrs)
+      content_tag(:a, url, attrs) + punctuation.reverse.join("")
     end
   end
 


### PR DESCRIPTION
Extracted and adjusted from [here](https://github.com/tenderlove/rails_autolink/blob/master/lib/rails_autolink/helpers.rb#L101-L116).

Counts the number of opening brackets in the url and compares with the number of closing brackets.

**Note:** `\p{L}` is a [PCRE](http://pcre.org/pcre.txt) regex matching any kind of letter in any language (unicode support). You can read more about this [here](http://www.regular-expressions.info/unicode.html).