### PR TITLE
Look around for &lt; html entity

### DIFF
--- a/spec/autolink_spec.cr
+++ b/spec/autolink_spec.cr
@@ -90,4 +90,9 @@ describe Autolink do
       auto_link(content).should eq content
     end
   end
+
+  it "can autolink url having escaped html" do
+    link = %q(<a href="example">http://example.com</a>).gsub("<", "&lt;")
+    auto_link(link).should eq %q(&lt;a href="example"><a href="http://example.com">http://example.com</a>&lt;/a>)
+  end
 end

--- a/src/autolink.cr
+++ b/src/autolink.cr
@@ -3,7 +3,7 @@ require "./autolink/*"
 module Autolink
   AUTO_LINK_RE = %r{
               (?: ((?:ed2k|ftp|http|https|irc|mailto|news|gopher|nntp|telnet|webcal|xmpp|callto|feed|svn|urn|aim|rsync|tag|ssh|sftp|rtsp|afs|file):)// | www\. )
-              [^\s<\"]+[^.<$]
+              ((.+?(?=&lt;)) | [^\s<\"]+)
             }ix
 
   AUTO_LINK_CRE = [/<[^>]+$/, /^[^>]*>/, /<a\b.*?>/i, /<\/a>/i]


### PR DESCRIPTION
refs https://github.com/veelenga/crystal-ann/pull/25

So now we are looking for `<` or `&lt;` (which is an html escaped equivalent) to match the end of the url. What do you think ?

