### PR TITLE
Don't escape '=' anymore

### DIFF
--- a/spec/autolink_spec.cr
+++ b/spec/autolink_spec.cr
@@ -98,7 +98,7 @@ describe Autolink do
     auto_link(link).should eq %q(&lt;a href="example"><a href="http://example.com">http://example.com</a>&lt;/a>)
 
     link = HTML.escape(%q(<a href="example">http://example.com</a>))
-    auto_link(link).should eq %q(&lt;a href&#61;&quot;example&quot;&gt;<a href="http://example.com">http://example.com</a>&lt;/a&gt;)
+    auto_link(link).should eq %q(&lt;a href=&quot;example&quot;&gt;<a href="http://example.com">http://example.com</a>&lt;/a&gt;)
   end
 
   it "plays well with stdlib markdown" do


### PR DESCRIPTION
To fix tests on Crystal 0.24.1

Ref: https://github.com/crystal-lang/crystal/pull/5012