### PR TITLE
Update version

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: autolink
-version: 0.1.1
+version: 0.1.3
 
 authors:
   - Hugo Abonizio <hugo_abonizio@hotmail.com>

--- a/src/autolink/version.cr
+++ b/src/autolink/version.cr
@@ -1,3 +1,3 @@
 module Autolink
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end


### PR DESCRIPTION
Hi @hugoabonizio 

This PR updates the version of this shard to follow the released tags (most recent is `v0.1.3`)