### PR TITLE
Fix test suite for Crystal 0.34.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -4,6 +4,6 @@ version: 0.1.3
 authors:
   - Hugo Abonizio <hugo_abonizio@hotmail.com>
 
-crystal: 0.24.2
+crystal: 0.34.0
 
 license: MIT

--- a/spec/autolink_spec.cr
+++ b/spec/autolink_spec.cr
@@ -1,6 +1,5 @@
 require "./spec_helper"
 require "html"
-require "markdown"
 
 describe Autolink do
   it "auto link URLs" do
@@ -99,19 +98,5 @@ describe Autolink do
 
     link = HTML.escape(%q(<a href="example">http://example.com</a>))
     auto_link(link).should eq %q(&lt;a href=&quot;example&quot;&gt;<a href="http://example.com">http://example.com</a>&lt;/a&gt;)
-  end
-
-  it "plays well with stdlib markdown" do
-    content = <<-EOF
-      auto_link("My blog: http://www.myblog.com")
-      My blog: <a href="http://www.myblog.com">http://www.myblog.com</a>
-      EOF
-
-    expected = <<-EOF
-      <p>auto_link("My blog: <a href="http://www.myblog.com">http://www.myblog.com</a>")
-      My blog: &lt;a href="http://www.myblog.com">http://www.myblog.com&lt;/a></p>
-      EOF
-
-    auto_link(Markdown.to_html(content)).should eq expected
   end
 end


### PR DESCRIPTION
[Markdown API was moved to inside the compiler](https://github.com/crystal-lang/crystal/pull/8115) and now is not part of the standard library, [its use is not recommended](https://github.com/crystal-lang/crystal/issues/9260#issuecomment-626165276) anymore.